### PR TITLE
sequential, restart between tests, cleaner matcher

### DIFF
--- a/src/test/scala/uk/co/deku/wiremock/Specs2.scala
+++ b/src/test/scala/uk/co/deku/wiremock/Specs2.scala
@@ -20,7 +20,7 @@ class Specs2 extends Specification {
   val wireMockServer = new WireMockServer(wireMockConfig().port(Port))
 
   step {
-    WireMock.configureFor("localhost", Port) //Must have it for any port other than 8080
+    WireMock.configureFor(Host, Port) //Must have it for any port other than 8080
     wireMockServer.start()
   }
 


### PR DESCRIPTION
- tests must run sequentially because interacting with WireMock and depends on a different setup for each test
- Start and stop the wiremock only once and restart between tests
- Cleaner way to match the 200 status code
